### PR TITLE
SHA routine requires AVX

### DIFF
--- a/hash_amd64.go
+++ b/hash_amd64.go
@@ -32,5 +32,5 @@ import (
 
 var hasAVX512 = cpuid.CPU.Supports(cpuid.AVX512F, cpuid.AVX512VL)
 var hasAVX2 = cpuid.CPU.Supports(cpuid.AVX2, cpuid.BMI2)
-var hasShani = cpuid.CPU.Supports(cpuid.SHA)
+var hasShani = cpuid.CPU.Supports(cpuid.SHA, cpuid.AVX)
 var supportedCPU = hasAVX2 || hasShani || hasAVX512


### PR DESCRIPTION
Our SHA routines breaks on CPUs that do not support AVX because of a VMOVDQU instruction. 

Fixes https://github.com/prysmaticlabs/prysm/issues/11202